### PR TITLE
implement goto {next,previous} untranslated message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+out
+node_modules
+.vscode-test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,22 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm"
+        },
+        {
+            "name": "Launch Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+    "version": "0.1.0",
+
+    // we want to run npm
+    "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
+
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
+
+    // The tsc compiler is started in watching mode
+    "isBackground": true,
+
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 Adds syntax highlight to `po`, `pot` and `potx` files.
 
 Source tmLanguage file: https://github.com/textmate/gettext.tmbundle/blob/master/Syntaxes/Gettext.tmLanguage
+
+## Features
+
+* `vscgettext.moveToNextUntranslated`: Move focus to next untranslated message (`alt+n`)
+* `vscgettext.moveToPreviousUntranslated`: Move focus to previous untranslated message (`alt+shift+n`)

--- a/package.json
+++ b/package.json
@@ -55,13 +55,17 @@
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "vstest": "node ./node_modules/vscode/bin/test"
+        "vstest": "node ./node_modules/vscode/bin/test",
+        "lint": "tslint src/**/*.ts test/*.test.ts"
     },
     "devDependencies": {
         "@types/chai": "^4.0.4",
         "@types/mocha": "^2.2.44",
         "@types/node": "^8.0.47",
         "chai": "^4.1.2",
+        "tslint": "^5.8.0",
+        "tslint-eslint-rules": "^4.1.1",
+        "tslint-microsoft-contrib": "^5.0.1",
         "typescript": "^2.5.3",
         "vscode": "^1.1.6"
     }

--- a/package.json
+++ b/package.json
@@ -4,23 +4,65 @@
     "description": "Gettext PO files language support for Visual Studio Code",
     "version": "0.0.1",
     "publisher": "mrorz",
+    "main": "./out/src/vscgettext",
     "engines": {
         "vscode": "^1.12.0"
     },
     "categories": [
         "Languages"
     ],
+    "activationEvents": [
+        "onCommand:vscgettext.moveToNextUntranslated",
+        "onCommand:vscgettext.moveToPreviousUntranslated"
+    ],
     "contributes": {
-        "languages": [{
-            "id": "po",
-            "aliases": ["gettext", "po"],
-            "extensions": [".po",".pot",".potx"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "po",
-            "scopeName": "source.po",
-            "path": "./syntaxes/po.tmLanguage"
-        }]
+        "languages": [
+            {
+                "id": "po",
+                "aliases": [
+                    "gettext",
+                    "po"
+                ],
+                "extensions": [
+                    ".po",
+                    ".pot",
+                    ".potx"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "po",
+                "scopeName": "source.po",
+                "path": "./syntaxes/po.tmLanguage"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "vscgettext.moveToNextUntranslated",
+                "key": "alt+n",
+                "when": "editorTextFocus && resourceLangId == po"
+            },
+            {
+                "command": "vscgettext.moveToPreviousUntranslated",
+                "key": "alt+shift+n",
+                "when": "editorTextFocus && resourceLangId == po"
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "vstest": "node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.44",
+        "@types/node": "^8.0.47",
+        "chai": "^4.1.2",
+        "typescript": "^2.5.3",
+        "vscode": "^1.1.6"
     }
 }

--- a/src/vscgettext.ts
+++ b/src/vscgettext.ts
@@ -1,0 +1,199 @@
+import * as vscode from 'vscode';
+
+const msgidStartRgx = /^msgid\s+"(.*?)"\s*$/;
+const msgstrStartRgx =  /^msgstr\s+"(.*?)"\s*$/;
+const msgctxtStartRgx =  /^msgctxt\s+"(.*?)"\s*$/;
+const continuationLineRgx = /^"(.*?)\s*"$/;
+
+
+interface Message {
+    msgid: string,
+    msgidLine: number,
+    msgstr: string,
+    msgstrLine: number,
+    msgctxt: string,
+    msgctxtLine: number,
+    firstline: number,
+    lastline: number,
+}
+
+
+export function moveCursorTo(editor: vscode.TextEditor, lineno: number, colno=0): vscode.Position {
+    const position = new vscode.Position(lineno, colno);
+    editor.selection = new vscode.Selection(position, position);
+    return position;
+}
+
+
+function focusOnMessage(editor: vscode.TextEditor, message: Message) {
+    const position = moveCursorTo(editor, message.msgstrLine, 8);
+    editor.revealRange(
+        new vscode.Range(position, position), 
+        vscode.TextEditorRevealType.InCenterIfOutsideViewport
+    );
+}
+
+
+function *documentLines(document: vscode.TextDocument, startline=1) {
+    for (let lineno=startline; lineno < document.lineCount; lineno++) {
+        yield document.lineAt(lineno);
+    }
+}
+
+
+function *backwardDocumentLines(document: vscode.TextDocument, startline=document.lineCount - 1) {
+    for (let lineno=startline; lineno >= 0; lineno--) {
+        yield document.lineAt(lineno);
+    }
+}
+
+
+function nextMessage(document: vscode.TextDocument, currentMessage: Message): Message {
+    for (const line of documentLines(document, currentMessage.lastline + 1)) {
+        if (line.text && !line.text.trim().startsWith('#')) {
+            return currentMessageDefinition(document, line.lineNumber);
+        }
+    }
+    return null;
+}
+
+
+function previousMessage(document: vscode.TextDocument, currentMessage: Message): Message {
+    for (const line of backwardDocumentLines(document, currentMessage.firstline - 1)) {
+        if (line.text && !line.text.trim().startsWith('#')) {
+            return currentMessageDefinition(document, line.lineNumber);
+        }
+    }
+    return null;
+}
+
+
+
+function currentMessageStart(document: vscode.TextDocument, currentLine: number): vscode.TextLine {
+    let msgidLine = null;
+    // go backwards to msgid definition
+    for (const line of backwardDocumentLines(document, currentLine)) {
+        if (msgidStartRgx.test(line.text)) {
+            // we hit a msgid which is good, but we still need to go backwards
+            // to check if we hit a msgctxt
+            msgidLine = line;
+            continue;
+        }
+        if (msgctxtStartRgx.test(line.text)) {
+            // if we're on a msgctxt definition, this is the current message
+            // definition start
+            return line;
+        }
+        if (msgstrStartRgx.test(line.text) && msgidLine !== null) {
+            // we hit a msgstr but we already hit a msgid definition, it means
+            // that we've reached another message definition, return the line of
+            // the msgid hit.
+            return msgidLine;
+        }
+    }
+    // if we've reached the beginning of the file, msgidLine won't have been set
+    // and we'll return null in that case.
+    return msgidLine;
+}
+
+
+export function currentMessageDefinition(document: vscode.TextDocument, currentline: number): Message {
+    const firstline = currentMessageStart(document, currentline);
+    if (firstline === null) {
+        return null;
+    }
+    
+    let currentProperty;
+    const message: Message = {
+        msgid: null,
+        msgidLine: null,
+        msgstr: null,
+        msgstrLine: null,
+        msgctxt: null,
+        msgctxtLine: null,
+        firstline: firstline.lineNumber,
+        lastline: firstline.lineNumber,
+    };
+
+    if (msgctxtStartRgx.test(firstline.text)) {
+        currentProperty = 'msgctxt';
+        message.msgctxt = msgctxtStartRgx.exec(firstline.text)[1];
+        message.msgctxtLine = firstline.lineNumber;
+    } else {
+        currentProperty = 'msgid';
+        message.msgid = msgidStartRgx.exec(firstline.text)[1];
+        message.msgidLine = firstline.lineNumber;
+    }
+
+    for(const line of documentLines(document, message.firstline + 1)) {
+        if (msgctxtStartRgx.test(line.text)) {
+            break;
+        }
+        if (msgidStartRgx.test(line.text)) {
+            if (message.msgid !== null) {
+                break;  // we are now on the next message, definition is over
+            }
+            message.msgid = msgidStartRgx.exec(line.text)[1];
+            message.msgidLine = line.lineNumber;
+            currentProperty = 'msgid';
+        }
+        if (msgstrStartRgx.test(line.text)) {
+            message.msgstr = msgstrStartRgx.exec(line.text)[1];
+            message.msgstrLine = line.lineNumber;
+            currentProperty = 'msgstr';
+        } else if (msgctxtStartRgx.test(line.text)) {
+            message.msgctxt = msgctxtStartRgx.exec(line.text)[1];
+            currentProperty = 'msgctxt';
+        } else if (continuationLineRgx.test(line.text)) {
+            message[currentProperty] += continuationLineRgx.exec(line.text)[1];
+        }
+        message.lastline++;
+    }
+
+    return message;
+}
+
+
+function nextUntranslatedMessage(document: vscode.TextDocument, lineno: number, backwards=false): Message {
+    let message = currentMessageDefinition(document, lineno);
+    const messageIterator = backwards ? previousMessage : nextMessage;
+    while (message !== null) {
+        message = messageIterator(document, message);
+        if (message && !message.msgstr) {
+            return message;
+        }
+    }
+    return null;
+}
+
+
+
+function _moveToNextUntranslatedMessage(editor: vscode.TextEditor, backwards=false) {
+    const position = editor.selection.active;
+    const message = nextUntranslatedMessage(editor.document, position.line, backwards);
+    if (message !== null) {
+        focusOnMessage(editor, message);
+    }    
+}
+
+
+export function moveToNextUntranslatedMessage(editor: vscode.TextEditor) {
+    _moveToNextUntranslatedMessage(editor);
+}
+
+
+export function moveToPreviousUntranslatedMessage(editor: vscode.TextEditor) {
+    _moveToNextUntranslatedMessage(editor, true);
+}
+
+
+export function activate(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+        vscode.commands.registerTextEditorCommand('vscgettext.moveToNextUntranslated', moveToNextUntranslatedMessage)
+    );
+    context.subscriptions.push(
+        vscode.commands.registerTextEditorCommand('vscgettext.moveToPreviousUntranslated', moveToPreviousUntranslatedMessage)
+    );
+}
+
+export function deactivate() {}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -18,10 +18,8 @@ function assertCursorAt(editor: vscode.TextEditor, lineno: number, colno: number
 
 
 function openFile(path): Thenable<vscode.TextEditor> {
-    let textDocument: vscode.TextDocument;
     return vscode.workspace.openTextDocument(inputpath('messages.po')).then(document => {
-        textDocument = document;
-        return vscode.window.showTextDocument(textDocument);
+        return vscode.window.showTextDocument(document);
     });
 }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,127 @@
+import {assert} from 'chai';
+import * as path from 'path';
+
+import * as vscode from "vscode";
+import * as vscgettext from "../src/vscgettext";
+
+
+function inputpath(basename: string): string {
+    return path.join(__dirname, '..', '..', 'test', 'inputfiles', basename);
+}
+
+
+function assertCursorAt(editor: vscode.TextEditor, lineno: number, colno: number) {
+    const selection = editor.selection.active;
+    const actualPos = {lineno: selection.line, colno: selection.character};
+    assert.deepEqual(actualPos, {lineno, colno});
+}
+
+
+function openFile(path): Thenable<vscode.TextEditor> {
+    let textDocument: vscode.TextDocument;
+    return vscode.workspace.openTextDocument(inputpath('messages.po')).then(document => {
+        textDocument = document;
+        return vscode.window.showTextDocument(textDocument);
+    });
+}
+
+suite("vscode-gettext tests", () => {
+    test('move to helper', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            vscgettext.moveCursorTo(editor, 10, 0);
+            assertCursorAt(editor, 10, 0);
+        }).then(done, done);
+    });
+
+    test('message definition parsing', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            const message = vscgettext.currentMessageDefinition(editor.document, 15);
+            assert.deepEqual(message, {
+                msgid: 'msgid1',
+                msgidLine: 15,
+                msgstr: 'message 1',
+                msgstrLine: 16,
+                msgctxt: null,
+                msgctxtLine: null,
+                firstline: 15,
+                lastline: 17,
+            })
+        }).then(done, done);
+    });
+
+    test('message definition parsing with msgctx', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            const message = vscgettext.currentMessageDefinition(editor.document, 27);
+            assert.deepEqual(message, {
+                msgid: 'agent_type',
+                msgidLine: 27,
+                msgstr: '',
+                msgstrLine: 28,
+                msgctxt: 'CorporateBody',
+                msgctxtLine: 26,
+                firstline: 26,
+                lastline: 29,
+            })
+        }).then(done, done);
+    });
+
+    test('message definition with msgid on multiple lines', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            const message = vscgettext.currentMessageDefinition(editor.document, 31);
+            assert.deepEqual(message, {
+                msgid: 'Another message on several lines.',
+                msgidLine: 30,
+                msgstr: 'translation on several lines too.',
+                msgstrLine: 32,
+                msgctxt: null,
+                msgctxtLine: null,
+                firstline: 30,
+                lastline: 34,
+            })
+        }).then(done, done);
+    });
+
+    test('editor jumps not next untranslated msgstr', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 10, 0);
+            // move to next untranslated message and check new position
+            vscgettext.moveToNextUntranslatedMessage(editor);
+            assertCursorAt(editor, 20, 8);
+            // now move again to make sure we don't stay on current message
+            vscgettext.moveToNextUntranslatedMessage(editor);
+            assertCursorAt(editor, 24, 8);
+        }).then(done, done);
+    });
+
+    test("editor doesn't move when on the last message of the file", done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 37, 0);
+            // move to next untranslated message and check new position
+            vscgettext.moveToNextUntranslatedMessage(editor);
+            assertCursorAt(editor, 37, 0);
+        }).then(done, done);
+    });
+
+    test('jump to previous untranslated message', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 37, 0);
+            // move to next untranslated message and check new position
+            vscgettext.moveToPreviousUntranslatedMessage(editor);
+            assertCursorAt(editor, 28, 8);
+        }).then(done, done);
+    });
+
+    test("editor doesn't move when on the first message of the file", done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 10, 0);
+            // move to next untranslated message and check new position
+            vscgettext.moveToPreviousUntranslatedMessage(editor);
+            assertCursorAt(editor, 10, 0);
+        }).then(done, done);
+    });
+
+});

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -18,7 +18,7 @@ function assertCursorAt(editor: vscode.TextEditor, lineno: number, colno: number
 
 
 function openFile(path): Thenable<vscode.TextEditor> {
-    return vscode.workspace.openTextDocument(inputpath('messages.po')).then(document => {
+    return vscode.workspace.openTextDocument(path).then(document => {
         return vscode.window.showTextDocument(document);
     });
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,14 +1,16 @@
-import {assert} from 'chai';
-import * as path from 'path';
+/**
+ * vsgettext extension tests
+ */
 
-import * as vscode from "vscode";
-import * as vscgettext from "../src/vscgettext";
+import { assert } from 'chai';
+import { join as pathjoin } from 'path';
 
+import * as vscode from 'vscode';
+import * as vscgettext from '../src/vscgettext';
 
 function inputpath(basename: string): string {
-    return path.join(__dirname, '..', '..', 'test', 'inputfiles', basename);
+    return pathjoin(__dirname, '..', '..', 'test', 'inputfiles', basename);
 }
-
 
 function assertCursorAt(editor: vscode.TextEditor, lineno: number, colno: number) {
     const selection = editor.selection.active;
@@ -16,14 +18,13 @@ function assertCursorAt(editor: vscode.TextEditor, lineno: number, colno: number
     assert.deepEqual(actualPos, {lineno, colno});
 }
 
-
 function openFile(path): Thenable<vscode.TextEditor> {
     return vscode.workspace.openTextDocument(path).then(document => {
         return vscode.window.showTextDocument(document);
     });
 }
 
-suite("vscode-gettext tests", () => {
+suite('vscode-gettext tests', () => {
     test('move to helper', done => {
         openFile(inputpath('messages.po')).then(editor => {
             vscgettext.moveCursorTo(editor, 10, 0);
@@ -43,7 +44,7 @@ suite("vscode-gettext tests", () => {
                 msgctxtLine: null,
                 firstline: 15,
                 lastline: 17,
-            })
+            });
         }).then(done, done);
     });
 
@@ -59,7 +60,7 @@ suite("vscode-gettext tests", () => {
                 msgctxtLine: 26,
                 firstline: 26,
                 lastline: 29,
-            })
+            });
         }).then(done, done);
     });
 
@@ -75,7 +76,7 @@ suite("vscode-gettext tests", () => {
                 msgctxtLine: null,
                 firstline: 30,
                 lastline: 34,
-            })
+            });
         }).then(done, done);
     });
 
@@ -92,7 +93,7 @@ suite("vscode-gettext tests", () => {
         }).then(done, done);
     });
 
-    test("editor doesn't move when on the last message of the file", done => {
+    test('editor doesn\'t move when on the last message of the file', done => {
         openFile(inputpath('messages.po')).then(editor => {
             // put the cursor somewhere in the file
             vscgettext.moveCursorTo(editor, 37, 0);
@@ -112,7 +113,7 @@ suite("vscode-gettext tests", () => {
         }).then(done, done);
     });
 
-    test("editor doesn't move when on the first message of the file", done => {
+    test('editor doesn\'t move when on the first message of the file', done => {
         openFile(inputpath('messages.po')).then(editor => {
             // put the cursor somewhere in the file
             vscgettext.moveCursorTo(editor, 10, 0);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/test/inputfiles/messages.po
+++ b/test/inputfiles/messages.po
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2017-10-28 00:00+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "msgid1"
+msgstr "message 1"
+
+msgid ""
+"A message on several lines."
+msgstr ""
+
+# some comment
+msgid "msgid2"
+msgstr ""
+
+msgctxt "CorporateBody"
+msgid "agent_type"
+msgstr ""
+
+msgid ""
+"Another message on several lines."
+msgstr ""
+"translation on several lines too."
+
+msgctxt "Person"
+msgid "agent_type"
+msgstr ""

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "."
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,25 @@
+{
+    "extends": [
+        "tslint-eslint-rules",
+        "tslint-microsoft-contrib"
+    ],
+    "rules": {
+        "typedef": false,
+        "newline-before-return": false,
+        "no-increment-decrement": false,
+        "no-relative-imports": false,
+        "whitespace": [false, "check-branch"],
+        "trailing-comma": [
+            true,
+            {
+              "multiline": {
+                "objects": "always",
+                "arrays": "always",
+                "functions": "never",
+                "typeLiterals": "ignore"
+              },
+              "esSpecCompliant": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Introduce two new commands:

- vscgettext.moveToNextUntranslated (alt+n)
- vscgettext.moveToPreviousUntranslated (alt+shift+n)

and add the whole test / debug tasks boilerplate.

cf. https://github.com/MrOrz/vscode-gettext/issues/3