### PR TITLE
Implement jumping to the next/prev fuzzy message

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Source tmLanguage file: https://github.com/textmate/gettext.tmbundle/blob/master
 
 * `vscgettext.moveToNextUntranslated`: Move focus to next untranslated message (`alt+n`)
 * `vscgettext.moveToPreviousUntranslated`: Move focus to previous untranslated message (`alt+shift+n`)
+* `vscgettext.moveToNextFuzzy`: Move focus to next fuzzy message (`alt+f`)
+* `vscgettext.moveToPreviousFuzzy`: Move focus to previous fuzzy message (`alt+shift+f`)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "activationEvents": [
         "onCommand:vscgettext.moveToNextUntranslated",
         "onCommand:vscgettext.moveToPreviousUntranslated",
+        "onCommand:vscgettext.moveToNextFuzzy",
+        "onCommand:vscgettext.moveToPreviousFuzzy",
         "onLanguage:po",
         "onLanguage:pot",
         "onLanguage:potx"
@@ -61,6 +63,16 @@
             {
                 "command": "vscgettext.moveToPreviousUntranslated",
                 "key": "alt+shift+n",
+                "when": "editorTextFocus && resourceLangId == po"
+            },
+            {
+                "command": "vscgettext.moveToNextFuzzy",
+                "key": "alt+f",
+                "when": "editorTextFocus && resourceLangId == po"
+            },
+            {
+                "command": "vscgettext.moveToPreviousFuzzy",
+                "key": "alt+shift+f",
                 "when": "editorTextFocus && resourceLangId == po"
             }
         ]

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -44,6 +44,7 @@ suite('vscode-gettext tests', () => {
                 msgctxtLine: null,
                 firstline: 15,
                 lastline: 17,
+                isfuzzy: false,
             });
         }).then(done, done);
     });
@@ -60,6 +61,7 @@ suite('vscode-gettext tests', () => {
                 msgctxtLine: 26,
                 firstline: 26,
                 lastline: 29,
+                isfuzzy: false,
             });
         }).then(done, done);
     });
@@ -76,6 +78,7 @@ suite('vscode-gettext tests', () => {
                 msgctxtLine: null,
                 firstline: 30,
                 lastline: 34,
+                isfuzzy: false,
             });
         }).then(done, done);
     });
@@ -96,10 +99,10 @@ suite('vscode-gettext tests', () => {
     test('editor doesn\'t move when on the last message of the file', done => {
         openFile(inputpath('messages.po')).then(editor => {
             // put the cursor somewhere in the file
-            vscgettext.moveCursorTo(editor, 37, 0);
+            vscgettext.moveCursorTo(editor, 42, 0);
             // move to next untranslated message and check new position
             vscgettext.moveToNextUntranslatedMessage(editor);
-            assertCursorAt(editor, 37, 0);
+            assertCursorAt(editor, 42, 0);
         }).then(done, done);
     });
 
@@ -123,4 +126,23 @@ suite('vscode-gettext tests', () => {
         }).then(done, done);
     });
 
+    test('jump to the previous fuzzy message', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 42, 0);
+            // move to next fuzzy message and check new position
+            vscgettext.moveToPreviousFuzzyMessage(editor);
+            assertCursorAt(editor, 38, 8);
+        }).then(done, done);
+    });
+
+    test('jump to the next fuzzy message', done => {
+        openFile(inputpath('messages.po')).then(editor => {
+            // put the cursor somewhere in the file
+            vscgettext.moveCursorTo(editor, 10, 0);
+            // move to next fuzzy message and check new position
+            vscgettext.moveToNextFuzzyMessage(editor);
+            assertCursorAt(editor, 38, 8);
+        }).then(done, done);
+    });
 });

--- a/test/inputfiles/messages.po
+++ b/test/inputfiles/messages.po
@@ -33,6 +33,11 @@ msgid ""
 msgstr ""
 "translation on several lines too."
 
+#, fuzzy, other-flags
+#| msgid "old text"
+msgid "new text"
+msgstr "old translation"
+
 msgctxt "Person"
 msgid "agent_type"
 msgstr ""


### PR DESCRIPTION
Fixes: #19 

- [x] ~Add tests for and support `#`, `#|`, and `#:`~ It seems that fuzzy comments only appear with `#,` comments which denote flags.
- [x] Add shortcut keys