### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm ci
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace


### PR DESCRIPTION
adding the missing id to provide publishing of the identical VSIX file

per example on https://github.com/HaaLeo/publish-vscode-extension; please to consider running it manually after the merge or release soon, to check if updating on open-vsx now works as expected