### PR TITLE
Separate vsix build and deploy steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: ${{ needs.build.outputs.vsixPath }}
-          skipDuplicate: true
 
   publish-to-vs-marketplace:
     runs-on: ubuntu-latest
@@ -57,4 +56,3 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{ needs.build.outputs.vsixPath }}
-          skipDuplicate: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 18
+      - run: npm ci
       - uses: HaaLeo/publish-vscode-extension@v1
         id: buildVsx
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           name: vsix
       - uses: HaaLeo/publish-vscode-extension@v1
-        id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: ${{ needs.build.outputs.vsixPath }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,22 +9,51 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      vsixPath: ${{ steps.buildVsx.outputs.vsixPath }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 18
-      - run: npm ci
-      - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
+      - uses: HaaLeo/publish-vscode-extension@v1
+        id: buildVsx
+        with:
+          pat: stub
+          dryRun: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: vsix
+          path: ${{ steps.buildVsx.outputs.vsixPath }}
+
+  publish-to-open-vsx:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download vsix
+        uses: actions/download-artifact@v2
+        with:
+          name: vsix
+      - uses: HaaLeo/publish-vscode-extension@v1
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-      - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+          extensionFile: ${{ needs.build.outputs.vsixPath }}
+          skipDuplicate: true
+
+  publish-to-vs-marketplace:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download vsix
+        uses: actions/download-artifact@v2
+        with:
+          name: vsix
+      - uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          extensionFile: ${{ needs.build.outputs.vsixPath }}
+          skipDuplicate: true


### PR DESCRIPTION
We separate vsix build, publish-to-VS marketplace and publish-to-OpenVSX into 3 jobs, so that we can just rerun failed jobs if we forgot to update any of the outdated tokens.

Example:
![圖片](https://github.com/MrOrz/vscode-gettext/assets/108608/a18201c1-9a2f-45c1-90dd-376a8ceec182)
https://github.com/MrOrz/vscode-gettext/actions/runs/7683610495

Note: the example is created with `skipDuplicate: true`. In this PR, I removed `skipDuplicate: true` because it may hide errors if we forgot to bump versions.