### PR TITLE
Show the output of `msgfmt --statistics` in the status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Source tmLanguage file: https://github.com/textmate/gettext.tmbundle/blob/master
 
 ## Features
 
+* Show the number of total messages, untranslated messages, and fuzzy messages in the status bar via `msgfmt --statistics`.
 * `vscgettext.moveToNextUntranslated`: Move focus to next untranslated message (`alt+n`)
 * `vscgettext.moveToPreviousUntranslated`: Move focus to previous untranslated message (`alt+shift+n`)
 * `vscgettext.moveToNextFuzzy`: Move focus to next fuzzy message (`alt+f`)

--- a/src/status.ts
+++ b/src/status.ts
@@ -24,10 +24,17 @@ export async function activateStatusBar({
 async function updateStsatusBarItem(): Promise<void> {
   const output = await runMsgfmtStatistics();
 
-  if (output) {
-    statusBarItem.text = output;
-    statusBarItem.show();
-  } else {
+  try {
+    if (output) {
+      statusBarItem.text = output;
+
+      statusBarItem.show();
+    } else {
+      statusBarItem.hide();
+    }
+  } catch (error) {
+    console.error(error);
+
     statusBarItem.hide();
   }
 }
@@ -44,9 +51,7 @@ async function runMsgfmtStatistics(): Promise<string | null> {
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
       if (error) {
-        console.error(stderr);
-
-        reject(error);
+        reject(new Error(`Failed to run msgfmt: ${error.message}`));
       } else {
         // Correct. The command will print the statistics to stderr.
         resolve(stderr);

--- a/src/status.ts
+++ b/src/status.ts
@@ -43,6 +43,10 @@ async function runMsgfmtStatistics(): Promise<string | null> {
 
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
+      console.log("error: ", error);
+      console.log("stdout: ", stdout);
+      console.log("stderr: ", stderr);
+
       // Correct. The command will print the statistics to stderr.
       resolve(stderr);
     });

--- a/src/status.ts
+++ b/src/status.ts
@@ -15,13 +15,13 @@ export async function activateStatusBar({
   subscriptions.push(statusBarItem);
 
   subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor(updateStsatusBarmItem)
+    vscode.window.onDidChangeActiveTextEditor(updateStsatusBarItem)
   );
 
-  updateStsatusBarmItem();
+  updateStsatusBarItem();
 }
 
-async function updateStsatusBarmItem(): Promise<void> {
+async function updateStsatusBarItem(): Promise<void> {
   const output = await runMsgfmtStatistics();
 
   if (output) {

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,39 @@
+import * as vscode from "vscode";
+import { exec } from "child_process";
+
+let statusBarItem: vscode.StatusBarItem;
+
+export async function activateStatusBar({
+  subscriptions,
+}: vscode.ExtensionContext): Promise<void> {
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    0
+  );
+
+  statusBarItem.show();
+  subscriptions.push(statusBarItem);
+
+  subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(updateStsatusBarmItem)
+  );
+
+  updateStsatusBarmItem();
+}
+
+async function updateStsatusBarmItem(): Promise<void> {
+  statusBarItem.text = await runMsgfmtStatistics();
+}
+
+async function runMsgfmtStatistics(): Promise<string> {
+  const path = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+  const command = `msgfmt --statistics -o /dev/null ${path}`;
+
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      // Correct. The command will print the statistics to stderr.
+      resolve(stderr);
+    });
+  });
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -22,11 +22,22 @@ export async function activateStatusBar({
 }
 
 async function updateStsatusBarmItem(): Promise<void> {
-  statusBarItem.text = await runMsgfmtStatistics();
+  const output = await runMsgfmtStatistics();
+
+  if (output) {
+    statusBarItem.text = output;
+    statusBarItem.show();
+  } else {
+    statusBarItem.hide();
+  }
 }
 
-async function runMsgfmtStatistics(): Promise<string> {
+async function runMsgfmtStatistics(): Promise<string | null> {
   const path = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+  if (!path) {
+    return null;
+  }
 
   const command = `msgfmt --statistics -o /dev/null ${path}`;
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -43,12 +43,14 @@ async function runMsgfmtStatistics(): Promise<string | null> {
 
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
-      console.log("error: ", error);
-      console.log("stdout: ", stdout);
-      console.log("stderr: ", stderr);
+      if (error) {
+        console.error(stderr);
 
-      // Correct. The command will print the statistics to stderr.
-      resolve(stderr);
+        reject(error);
+      } else {
+        // Correct. The command will print the statistics to stderr.
+        resolve(stderr);
+      }
     });
   });
 }

--- a/src/vscgettext.ts
+++ b/src/vscgettext.ts
@@ -12,8 +12,9 @@ import {
   moveToPreviousUntranslatedOrFuzzyMessage,
 } from "./lib";
 import provideDefinition from "./provide_definition";
+import { activateStatusBar } from "./status";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand(
       "vscgettext.moveToNextUntranslated",
@@ -53,6 +54,8 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider("po", { provideDefinition })
   );
+
+  activateStatusBar(context);
 }
 
 export function deactivate() {


### PR DESCRIPTION
Partially fixes #4. This prints the counts of total, untranslated, and fuzzy messages.
