### PR TITLE
Add document formatting with `msgattrib`

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import { exec } from "child_process";
+
+export const provideDocumentFormattingEdits = async (
+  document: vscode.TextDocument,
+  _options: vscode.FormattingOptions,
+  token: vscode.CancellationToken
+) =>
+  runMsgAttr().then((newText) => {
+    const edit = vscode.TextEdit.replace(
+      new vscode.Range(0, 0, document.lineCount, 0),
+      newText
+    );
+    return token.isCancellationRequested ? [] : [edit];
+  });
+
+function runMsgAttr(): Promise<string | null> {
+  const path = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+  if (!path) {
+    return null;
+  }
+
+  const command = `msgattrib ${path}`;
+
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        vscode.window.showErrorMessage(`Failed to run msgattrib: ${stderr}`);
+        reject(new Error(`Failed to run msgattrib: ${error.message}`));
+      } else {
+        // msgattrib printed the formatted file to stdout.
+        resolve(stdout);
+      }
+    });
+  });
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -51,6 +51,7 @@ async function runMsgfmtStatistics(): Promise<string | null> {
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
       if (error) {
+        vscode.window.showErrorMessage(`Failed to run msgfmt: ${stderr}`);
         reject(new Error(`Failed to run msgfmt: ${error.message}`));
       } else {
         // Correct. The command will print the statistics to stderr.

--- a/src/vscgettext.ts
+++ b/src/vscgettext.ts
@@ -12,6 +12,7 @@ import {
   moveToPreviousUntranslatedOrFuzzyMessage,
 } from "./lib";
 import provideDefinition from "./provide_definition";
+import { provideDocumentFormattingEdits } from "./formatting";
 import { activateStatusBar } from "./status";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -53,6 +54,12 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider("po", { provideDefinition })
+  );
+
+  context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider("po", {
+      provideDocumentFormattingEdits,
+    })
   );
 
   activateStatusBar(context);


### PR DESCRIPTION
I've added the possibility of formatting a whole PO file from the editor using the output of `msgattrib`. This command automatically wraps long lines and corrects possible quoting or syntax mistakes, which is pretty handy.

The formatting is applied when a PO file is saved (e.g. with <kbd>Ctrl</kbd>+<kbd>S</kbd>), or by issuing `Format Document` command.

I've also improved the error reporting of the status bar by showing an error notification when `msgfmt --statistic` fails, so the user knows something is wrong.

Please let me know if something can be improved!